### PR TITLE
Allows to pass arbitrary file descriptor on unix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! A simple utility for getting the size of a terminal.  
-//! 
+//!
 //! Supports both Linux and Windows, but help is needed to test other platforms
 //!
 //! Tested on Rust Stable (1.4), Beta (1.5), and Nightly (1.6)
@@ -28,10 +28,7 @@ mod unix;
 #[cfg(unix)]
 pub use unix::terminal_size;
 
-
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
 pub use windows::terminal_size;
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub struct Height(pub u16);
 mod unix;
 #[cfg(unix)]
 pub use unix::terminal_size;
+pub use unix::terminal_size_using_fd;
 
 #[cfg(windows)]
 mod windows;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,34 +1,35 @@
-
 extern crate winapi;
 
-use super::{Width, Height};
+use super::{Height, Width};
 
 /// Returns the size of the terminal, if available.
 ///
 /// Note that this returns the size of the actual command window, and
 /// not the overall size of the command window buffer
 pub fn terminal_size() -> Option<(Width, Height)> {
-    use self::winapi::um::winnt::HANDLE;
-    use self::winapi::um::processenv::{GetStdHandle};
+    use self::winapi::um::processenv::GetStdHandle;
     use self::winapi::um::winbase::{STD_INPUT_HANDLE, STD_OUTPUT_HANDLE};
-    use self::winapi::um::wincon::{GetConsoleScreenBufferInfo, CONSOLE_SCREEN_BUFFER_INFO, COORD, SMALL_RECT};
-
-    let hand: HANDLE = unsafe {
-        GetStdHandle(STD_OUTPUT_HANDLE)
+    use self::winapi::um::wincon::{
+        GetConsoleScreenBufferInfo, CONSOLE_SCREEN_BUFFER_INFO, COORD, SMALL_RECT,
     };
+    use self::winapi::um::winnt::HANDLE;
 
-    let zc = COORD{X: 0, Y: 0};
-    let mut csbi = CONSOLE_SCREEN_BUFFER_INFO{
+    let hand: HANDLE = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+
+    let zc = COORD { X: 0, Y: 0 };
+    let mut csbi = CONSOLE_SCREEN_BUFFER_INFO {
         dwSize: zc.clone(),
         dwCursorPosition: zc.clone(),
         wAttributes: 0,
-        srWindow: SMALL_RECT{Left:0, Top: 0, Right: 0, Bottom: 0},
-        dwMaximumWindowSize: zc
-
+        srWindow: SMALL_RECT {
+            Left: 0,
+            Top: 0,
+            Right: 0,
+            Bottom: 0,
+        },
+        dwMaximumWindowSize: zc,
     };
-    let success:bool = unsafe {
-        GetConsoleScreenBufferInfo(hand, &mut csbi) != 0
-    };
+    let success: bool = unsafe { GetConsoleScreenBufferInfo(hand, &mut csbi) != 0 };
     if success {
         let w: Width = Width((csbi.srWindow.Right - csbi.srWindow.Left + 1) as u16);
         let h: Height = Height((csbi.srWindow.Bottom - csbi.srWindow.Top + 1) as u16);


### PR DESCRIPTION
Adds terminal_size_using_fd function that can be passed any file descriptor instead of just STDOUT_FILENO.

Useful in the case that STDOUT is being piped, can use the file descriptor given by /dev/tty.

Can be used like so:
```rust
extern crate terminal_size;

use std::fs::File;
use std::os::unix::io::AsRawFd;
use terminal_size::terminal_size_using_fd;

fn main() {
    let tty = File::open("/dev/tty").expect("Failed to open /dev/tty");

    let ts = terminal_size_using_fd(tty.as_raw_fd()).expect("Failed to get term size");

    println!("{:?}", ts);
}
```