### PR TITLE
Update crate for Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "http://eminence.github.io/terminal-size/doc/terminal_size/index
 repository = "https://github.com/eminence/terminal-size"
 keywords = ["terminal", "console", "term", "size", "dimensions"]
 license = "MIT OR Apache-2.0"
+edition = "2018"
 
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,8 @@ pub struct Height(pub u16);
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]
-pub use unix::terminal_size;
-pub use unix::terminal_size_using_fd;
+pub use crate::unix::terminal_size;
+pub use crate::unix::terminal_size_using_fd;
 
 #[cfg(windows)]
 mod windows;


### PR DESCRIPTION
Update crate for Rust 2018 using 'cargo fix --edition'