### PR TITLE
Don't depend on libc on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 
-[dependencies]
-libc = "0.2"
+[target.'cfg(not(windows))'.dependencies.libc]
+version = "0.2"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"


### PR DESCRIPTION
This dependency is never used when `target == windows`, but it's still build