### PR TITLE
Allow dependencies using terminal_size to compile even on non-supported platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,3 +32,6 @@ pub use crate::unix::{terminal_size, terminal_size_using_fd};
 mod windows;
 #[cfg(windows)]
 pub use windows::{terminal_size, terminal_size_using_handle};
+
+#[cfg(not(any(unix, windows)))]
+pub fn terminal_size() -> Option<(Width, Height)> { None }


### PR DESCRIPTION
(Looking at wasm32-wasi here.)