### PR TITLE
add test support for illumos systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ terminal-size
 
 Rust library to getting the size of your terminal.
 
-Works on Linux, MacOS, and Windows.
+Works on Linux, MacOS, Windows, and illumos.
 
 ```rust
 use terminal_size::{Width, Height, terminal_size};

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -48,30 +48,64 @@ fn compare_with_stty() {
     use std::process::Command;
     use std::process::Stdio;
 
-    let output = if cfg!(target_os = "linux") {
-        Command::new("stty")
-            .arg("size")
-            .arg("-F")
-            .arg("/dev/stderr")
-            .stderr(Stdio::inherit())
+    let (rows, cols) = if cfg!(target_os = "illumos") {
+        // illumos stty(1) does not accept a device argument, instead using
+        // stdin unconditionally:
+        let output = Command::new("stty")
+            .stdin(Stdio::inherit())
             .output()
+            .unwrap();
+        assert!(output.status.success());
+
+        // stdout includes the row and columns thus: "rows = 80; columns = 24;"
+        let vals = String::from_utf8(output.stdout)
             .unwrap()
+            .lines()
+            .map(|line| {
+                // Split each line on semicolons to get "k = v" strings:
+                line.split(';')
+                    .map(str::trim)
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .flatten()
+            .filter_map(|term| {
+                // split each "k = v" string and look for rows/columns:
+                match term.splitn(2, " = ").collect::<Vec<_>>().as_slice() {
+                    ["rows", n] | ["columns", n] => Some(n.parse().unwrap()),
+                    _ => None,
+                }
+            })
+            .collect::<Vec<_>>();
+        (vals[0], vals[1])
     } else {
-        Command::new("stty")
-            .arg("-f")
-            .arg("/dev/stderr")
-            .arg("size")
-            .stderr(Stdio::inherit())
-            .output()
-            .unwrap()
+        let output = if cfg!(target_os = "linux") {
+            Command::new("stty")
+                .arg("size")
+                .arg("-F")
+                .arg("/dev/stderr")
+                .stderr(Stdio::inherit())
+                .output()
+                .unwrap()
+        } else {
+            Command::new("stty")
+                .arg("-f")
+                .arg("/dev/stderr")
+                .arg("size")
+                .stderr(Stdio::inherit())
+                .output()
+                .unwrap()
+        };
+
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        // stdout is "rows cols"
+        let mut data = stdout.split_whitespace();
+        println!("{}", stdout);
+        let rows = u16::from_str_radix(data.next().unwrap(), 10).unwrap();
+        let cols = u16::from_str_radix(data.next().unwrap(), 10).unwrap();
+        (rows, cols)
     };
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(output.status.success());
-    // stdout is "rows cols"
-    let mut data = stdout.split_whitespace();
-    let rows = u16::from_str_radix(data.next().unwrap(), 10).unwrap();
-    let cols = u16::from_str_radix(data.next().unwrap(), 10).unwrap();
-    println!("{}", stdout);
     println!("{} {}", rows, cols);
 
     if let Some((Width(w), Height(h))) = terminal_size() {


### PR DESCRIPTION
With this change, the tests pass on illumos systems:

```
$ uname -a
SunOS newcastle 5.11 rti-master-0-gf6ef42236c i86pc i386 i86pc

$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.01s
     Running target/debug/deps/terminal_size-5a275fee5117c2f0

running 1 test
test unix::compare_with_stty ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests terminal_size

running 1 test
test src/lib.rs - (line 9) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.29s
```

Note that in the end I only needed to fix the test for our `stty`.  The library itself already appears to work correctly.