### PR TITLE
Migrate from winapi to windows-sys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,9 @@ edition = "2018"
 [target.'cfg(not(windows))'.dependencies.libc]
 version = "0.2"
 
-[target.'cfg(windows)'.dependencies.winapi]
-version = "0.3"
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.0"
 features = [
-    "handleapi",
-    "processenv",
-    "winbase",
-    "wincon",
-    "winnt",
+    "Win32_Foundation",
+    "Win32_System_Console",
 ]

--- a/examples/get_size.rs
+++ b/examples/get_size.rs
@@ -1,8 +1,9 @@
 #[cfg(windows)]
 fn run() {
     use std::os::windows::io::RawHandle;
-    use winapi::um::processenv::GetStdHandle;
-    use winapi::um::winbase::{STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE};
+    use windows_sys::Win32::System::Console::{
+        GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+    };
 
     let stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) } as RawHandle;
     println!(

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -6,8 +6,7 @@ use std::os::windows::io::RawHandle;
 /// Note that this returns the size of the actual command window, and
 /// not the overall size of the command window buffer
 pub fn terminal_size() -> Option<(Width, Height)> {
-    use winapi::um::processenv::GetStdHandle;
-    use winapi::um::winbase::STD_OUTPUT_HANDLE;
+    use windows_sys::Win32::System::Console::{GetStdHandle, STD_OUTPUT_HANDLE};
 
     let handle = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) as RawHandle };
 
@@ -18,13 +17,13 @@ pub fn terminal_size() -> Option<(Width, Height)> {
 ///
 /// If the given handle is not a tty, returns `None`
 pub fn terminal_size_using_handle(handle: RawHandle) -> Option<(Width, Height)> {
-    use winapi::um::handleapi::INVALID_HANDLE_VALUE;
-    use winapi::um::wincon::{
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::System::Console::{
         GetConsoleScreenBufferInfo, CONSOLE_SCREEN_BUFFER_INFO, COORD, SMALL_RECT,
     };
 
-    // convert between winapi::um::winnt::HANDLE and std::os::windows::raw::HANDLE
-    let hand = handle as winapi::um::winnt::HANDLE;
+    // convert between windows_sys::Win32::Foundation::HANDLE and std::os::windows::raw::HANDLE
+    let hand = handle as windows_sys::Win32::Foundation::HANDLE;
 
     if hand == INVALID_HANDLE_VALUE {
         return None;


### PR DESCRIPTION
This PR migrates terminal_size from winapi to windows-sys.

Windows-sys is actively maintained, by Microsoft, and has recently
started to be adopted in the ecosystem; mio, parking_lot, wasmtime,
and others have moved to windows-sys.

Migrating terminal_size to windows-sys will help me remove one more of
Wasmtime's transitive dependencies on winapi.