### PR TITLE
Migrate from libc to rustix.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         build: [linux, macos, windows]
+        toolchain: ["1.48.0", "stable", "beta", "nightly"]
         include:
           - build: linux
             os: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 
-[target.'cfg(not(windows))'.dependencies.libc]
-version = "0.2"
+[target.'cfg(not(windows))'.dependencies]
+rustix = { version = "0.35.6", features = ["termios"] }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ if let Some((Width(w), Height(h))) = size {
 
 ## Minimum Rust Version
 
-This crate requires a minimum rust version of 1.31.0 (2018-12-06)
+This crate requires a minimum rust version of 1.48.0 (2020-11-19)
 
 ## License
 

--- a/examples/get_size.rs
+++ b/examples/get_size.rs
@@ -25,17 +25,19 @@ fn run() {
 
 #[cfg(not(windows))]
 fn run() {
+    use std::os::unix::io::AsRawFd;
+
     println!(
         "Size from terminal_size_using_fd(stdout):     {:?}",
-        terminal_size::terminal_size_using_fd(libc::STDOUT_FILENO)
+        terminal_size::terminal_size_using_fd(std::io::stdout().as_raw_fd())
     );
     println!(
         "Size from terminal_size_using_fd(stderr):     {:?}",
-        terminal_size::terminal_size_using_fd(libc::STDERR_FILENO)
+        terminal_size::terminal_size_using_fd(std::io::stderr().as_raw_fd())
     );
     println!(
         "Size from terminal_size_using_fd(stdin):      {:?}",
-        terminal_size::terminal_size_using_fd(libc::STDIN_FILENO)
+        terminal_size::terminal_size_using_fd(std::io::stdin().as_raw_fd())
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Supports both Linux, MacOS, and Windows.
 //!
-//!  This crate requires a minimum rust version of 1.31.0 (2018-12-06)
+//!  This crate requires a minimum rust version of 1.48.0 (2020-11-19)
 //!
 //! # Example
 //!


### PR DESCRIPTION
This migrates terminal_size from using libc directly to using rustix,
which eliminates a few unsafe blocks and manual error handling.

It does also add one new unsafe block, though this is because
`terminal_size_using_fd` is a public safe function that has a `RawFd`
argument. With [I/O safety], which is expected to be [stabilized in Rust 1.63],
there will be new guidance saying be that [such functions should be unsafe].
It's not urgent to make any changes for this right now though.

This also updates the minimum Rust version to 1.48, which is about as
old as the previous minimum Rust version was when it was last updated.

[I/O safety]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md
[stabilized in Rust 1.63]: https://github.com/rust-lang/rust/issues/87074
[such functions should be unsafe]: https://doc.rust-lang.org/nightly/std/os/unix/io/index.html