### PR TITLE
Optimize away a call to `std::io::stdout()`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.35.6", features = ["termios"] }
+rustix = { version = "0.35.7", features = ["termios"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.36.0"

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,12 +1,12 @@
 use super::{Height, Width};
 use std::os::unix::io::RawFd;
-use rustix::fd::{BorrowedFd, AsRawFd};
+use rustix::fd::BorrowedFd;
 
 /// Returns the size of the terminal defaulting to STDOUT, if available.
 ///
 /// If STDOUT is not a tty, returns `None`
 pub fn terminal_size() -> Option<(Width, Height)> {
-    terminal_size_using_fd(std::io::stdout().as_raw_fd())
+    terminal_size_using_fd(rustix::io::raw_stdout())
 }
 
 /// Returns the size of the terminal using the given file descriptor, if available.


### PR DESCRIPTION
The code added in #33 called `std::io::stdout` just to call `as_raw_fd`
on the result. But calling `std::io::stdout` involves acquiring a lock,
and it doesn't fully optimize away. So instead, call
`rustix::io::raw_stdout`, which just returns the stdout file descriptor
directly, without doing anything else.

This shaves off 444 bytes of binary size, which is enough to give
terminal-size 0.2 a slightly smaller code-size footprint in release
builds than even terminal-size 0.1.