### PR TITLE
Switch away from actions-rs and minor CI improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain: [1.48.0, stable, beta, nightly]
     steps:
-      - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@master
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
       - name: Cargo build
@@ -41,17 +43,19 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           targets: aarch64-linux-android,i686-unknown-linux-gnu
-      - name: cargo build (aarch64)
+      - name: Cargo check (aarch64)
         run: cargo +${{ matrix.toolchain }} check --target aarch64-linux-android
-      - name: cargo build (i686)
+      - name: Cargo check (i686)
         run: cargo +${{ matrix.toolchain }} check --target i686-unknown-linux-gnu
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Install faketty
         run: cargo install faketty
       - name: Cargo test (under faketty)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,15 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [linux, macos, windows]
-        toolchain: ["1.48.0", "stable", "beta", "nightly"]
-        include:
-          - build: linux
-            os: ubuntu-latest
-          - build: macos
-            os: macos-latest
-          - build: windows
-            os: windows-latest
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain: [1.48.0, stable, beta, nightly]
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,9 +44,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           targets: aarch64-linux-android,i686-unknown-linux-gnu
       - name: Cargo check (aarch64)
-        run: cargo +${{ matrix.toolchain }} check --target aarch64-linux-android
+        run: cargo check --target aarch64-linux-android
       - name: Cargo check (i686)
-        run: cargo +${{ matrix.toolchain }} check --target i686-unknown-linux-gnu
+        run: cargo check --target i686-unknown-linux-gnu
 
   test:
     name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,31 +30,36 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
-      - name: Install toolchains (aarch64)
-        uses: actions-rs/toolchain@v1
-        if: contains(matrix.os, 'ubuntu')
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          target: aarch64-linux-android
-      - name: Install toolchains (i686)
-        uses: actions-rs/toolchain@v1
-        if: contains(matrix.os, 'ubuntu')
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          target: i686-unknown-linux-gnu
-
       - uses: actions-rs/cargo@v1
         name: Cargo build
         with:
           command: build
           toolchain: ${{ matrix.toolchain }}
 
+  cross:
+    name: Cross
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [1.48.0, stable, beta, nightly]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install toolchains (aarch64)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          target: aarch64-linux-android
+      - name: Install toolchains (i686)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          target: i686-unknown-linux-gnu
       - name: cargo build (aarch64)
         run: cargo +${{ matrix.toolchain }} check --target aarch64-linux-android
-        if: contains(matrix.os, 'ubuntu')
       - name: cargo build (i686)
         run: cargo +${{ matrix.toolchain }} check --target i686-unknown-linux-gnu
-        if: contains(matrix.os, 'ubuntu')
 
   test:
     name: Test
@@ -72,4 +77,3 @@ jobs:
 
       - name: Cargo test (under faketty)
         run: faketty cargo test -- --nocapture
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,14 +27,11 @@ jobs:
             os: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-      - uses: actions-rs/cargo@v1
-        name: Cargo build
-        with:
-          command: build
-          toolchain: ${{ matrix.toolchain }}
+      - name: Cargo build
+        run: cargo build
 
   cross:
     name: Cross
@@ -46,16 +43,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Install toolchains (aarch64)
-        uses: actions-rs/toolchain@v1
+      - name: Install toolchain and targets
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          target: aarch64-linux-android
-      - name: Install toolchains (i686)
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          target: i686-unknown-linux-gnu
+          targets: aarch64-linux-android,i686-unknown-linux-gnu
       - name: cargo build (aarch64)
         run: cargo +${{ matrix.toolchain }} check --target aarch64-linux-android
       - name: cargo build (i686)
@@ -66,14 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        name: Install faketty
-        with:
-          command: install
-          args: faketty
-
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install faketty
+        run: cargo install faketty
       - name: Cargo test (under faketty)
         run: faketty cargo test -- --nocapture


### PR DESCRIPTION
The actions-rs organization is unmaintained with the sole member being unresponsive for close to two years. Switch form actions-rs/toolchain to dtolnay/rust-toolchain and from actions-rs/cargo to plain cargo commands.

While at it, I've cleaned up the CI script a bit. Best reviewed on a commit by commit basis.

Note that updating actions/checkout to v3 has been intentionally left out here as a test case for dependabot. A PR adding a dependabot config will follow shortly.