### PR TITLE
Add a dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot will automatically file PRs for updatable dependencies. The
`cargo` section watches Cargo.toml. Patch releases are ignored since those
are semver compatible and cargo downloads the latest anyway.
The `github-actions` section watches the workflow files in .github/workflows
for possible updates to any of the Actions depended upon.

Kindly merge https://github.com/eminence/terminal-size/pull/39 first to avoid conflicts.