### PR TITLE
Add common traits to Width and Height

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,9 @@
 //! ```
 //!
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Width(pub u16);
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Height(pub u16);
 
 #[cfg(unix)]


### PR DESCRIPTION
Add `Clone`, `Copy`, `Eq`, and `Ord` to `Width` and `Height` structs, for convenience.