### PR TITLE
Update to rustix 0.37.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.36.3", features = ["termios"] }
+rustix = { version = "0.37.0", features = ["termios"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.45.0"


### PR DESCRIPTION
terminal-size doesn't need any code changes to update to rustix 0.37.