### PR TITLE
Update to rustix 0.38

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [1.48.0, stable, beta, nightly]
+        toolchain: [1.63.0, stable, beta, nightly]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [1.48.0, stable, beta, nightly]
+        toolchain: [1.63.0, stable, beta, nightly]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/crate/terminal_size"
 repository = "https://github.com/eminence/terminal-size"
 keywords = ["terminal", "console", "term", "size", "dimensions"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 
 [target.'cfg(not(windows))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.37.0", features = ["termios"] }
+rustix = { version = "0.38.0", features = ["termios"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48.0"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ if let Some((Width(w), Height(h))) = size {
 
 ## Minimum Rust Version
 
-This crate requires a minimum rust version of 1.48.0 (2020-11-19)
+This crate requires a minimum rust version of 1.63.0 (2022-08-11)
 
 ## License
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,5 +1,5 @@
 use super::{Height, Width};
-use rustix::fd::BorrowedFd;
+use rustix::fd::{BorrowedFd, AsRawFd};
 use std::os::unix::io::RawFd;
 
 /// Returns the size of the terminal.
@@ -8,11 +8,11 @@ use std::os::unix::io::RawFd;
 /// The size of the first stream that is a TTY will be returned.  If nothing
 /// is a TTY, then `None` is returned.
 pub fn terminal_size() -> Option<(Width, Height)> {
-    if let Some(size) = terminal_size_using_fd(rustix::io::raw_stdout()) {
+    if let Some(size) = terminal_size_using_fd(std::io::stdout().as_raw_fd()) {
         Some(size)
-    } else if let Some(size) = terminal_size_using_fd(rustix::io::raw_stderr()) {
+    } else if let Some(size) = terminal_size_using_fd(std::io::stderr().as_raw_fd()) {
         Some(size)
-    } else if let Some(size) = terminal_size_using_fd(rustix::io::raw_stdin()) {
+    } else if let Some(size) = terminal_size_using_fd(std::io::stdin().as_raw_fd()) {
         Some(size)
     } else {
         None


### PR DESCRIPTION
This upgrade is meant to bring support for mips32r6 and mips64r6, two Tier-3 architectures that have recently got their own `target_arch` values.