### PR TITLE
Add `rust-version` in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/eminence/terminal-size"
 keywords = ["terminal", "console", "term", "size", "dimensions"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.63"
 
 
 [target.'cfg(not(windows))'.dependencies]


### PR DESCRIPTION
cc https://github.com/eminence/terminal-size/issues/59

This is the standard way to encode MSRV and in the future may be read by more tooling.