### PR TITLE
Get terminal window size on Unix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,26 +14,31 @@
 //!     println!("Your terminal is {} cols wide and {} lines tall", w, h);
 //! } else {
 //!     println!("Unable to get terminal size");
-//! }
-//! ```
-//!
+}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Width(pub u16);
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Height(pub u16);
+pub struct WindowSize {
+    pub x: u16,
+    pub y: u16,
+}
 
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]
-pub use crate::unix::{terminal_size, terminal_size_using_fd};
+pub use crate::unix::{
+    terminal_size, terminal_size_full, terminal_size_full_from_fd, terminal_size_using_fd,
+};
 
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-pub use crate::windows::{terminal_size, terminal_size_using_handle};
+pub use crate::windows::{terminal_size, terminal_size_full, terminal_size_using_handle};
 
 #[cfg(not(any(unix, windows)))]
 pub fn terminal_size() -> Option<(Width, Height)> {
+    None
+}
+
+#[cfg(not(any(unix, windows)))]
+pub fn terminal_size_full() -> Option<(Width, Height, Option<WindowSize>)> {
     None
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -65,14 +65,13 @@ fn compare_with_stty() {
         let vals = String::from_utf8(output.stdout)
             .unwrap()
             .lines()
-            .map(|line| {
+            .flat_map(|line| {
                 // Split each line on semicolons to get "k = v" strings:
                 line.split(';')
                     .map(str::trim)
                     .map(str::to_string)
                     .collect::<Vec<_>>()
             })
-            .flatten()
             .filter_map(|term| {
                 // split each "k = v" string and look for rows/columns:
                 match term.splitn(2, " = ").collect::<Vec<_>>().as_slice() {
@@ -106,8 +105,8 @@ fn compare_with_stty() {
         // stdout is "rows cols"
         let mut data = stdout.split_whitespace();
         println!("{}", stdout);
-        let rows = u16::from_str_radix(data.next().unwrap(), 10).unwrap();
-        let cols = u16::from_str_radix(data.next().unwrap(), 10).unwrap();
+        let rows = data.next().unwrap().parse::<u16>().unwrap();
+        let cols = data.next().unwrap().parse::<u16>().unwrap();
         (rows, cols)
     };
     println!("{} {}", rows, cols);

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,3 +1,5 @@
+use crate::WindowSize;
+
 use super::{Height, Width};
 use std::os::windows::io::RawHandle;
 
@@ -21,6 +23,13 @@ pub fn terminal_size() -> Option<(Width, Height)> {
         .or_else(|| {
             terminal_size_using_handle(unsafe { GetStdHandle(STD_INPUT_HANDLE) as RawHandle })
         })
+}
+
+/// Returns the full size of the terminal.
+///
+/// On Windows, the last element is always `None` currently.
+pub fn terminal_size_full() -> Option<(Width, Height, Option<WindowSize>)> {
+    terminal_size().map(|(w, h)| (w, h, None))
 }
 
 /// Returns the size of the terminal using the given handle, if available.

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -14,21 +14,13 @@ pub fn terminal_size() -> Option<(Width, Height)> {
         GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
     };
 
-    if let Some(size) =
-        terminal_size_using_handle(unsafe { GetStdHandle(STD_OUTPUT_HANDLE) as RawHandle })
-    {
-        Some(size)
-    } else if let Some(size) =
-        terminal_size_using_handle(unsafe { GetStdHandle(STD_ERROR_HANDLE) as RawHandle })
-    {
-        Some(size)
-    } else if let Some(size) =
-        terminal_size_using_handle(unsafe { GetStdHandle(STD_INPUT_HANDLE) as RawHandle })
-    {
-        Some(size)
-    } else {
-        None
-    }
+    terminal_size_using_handle(unsafe { GetStdHandle(STD_OUTPUT_HANDLE) as RawHandle })
+        .or_else(|| {
+            terminal_size_using_handle(unsafe { GetStdHandle(STD_ERROR_HANDLE) as RawHandle })
+        })
+        .or_else(|| {
+            terminal_size_using_handle(unsafe { GetStdHandle(STD_INPUT_HANDLE) as RawHandle })
+        })
 }
 
 /// Returns the size of the terminal using the given handle, if available.


### PR DESCRIPTION
Get complete terminal size on Unix

On Unix, the terminal can also report the window size in pixels which is frequently required for more advanced terminal features, e.g proper image rendering and scaling on Kitty requires client programs to calculate the cell size.

* Add `terminal_size_full()` for both Unix and Windows, the latter not reporting any window size currently.
* Add `terminal_size_full_from_fd` on Unix, backing `terminal_size_full`, and providing an IO-safe alternative to `terminal_size_using_fd`.
* Deprecate `terminal_size_using_fd` because it's not IO safe.
* Fixed a few minor clippy lints.

These changes should all be sem-ver compatible.