### PR TITLE
Update `windows-sys` to 0.52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.63"
 rustix = { version = "0.38.0", features = ["termios"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48.0"
+version = "0.52.0"
 features = [
     "Win32_Foundation",
     "Win32_System_Console",


### PR DESCRIPTION
This should resolve some Windows deployment issues we've been having with [xiph/rav1e](https://github.com/xiph/rav1e). We've been manually preventing `windows-sys` upgrade to `0.48.5` in our `Cargo.lock` as it was causing `x86_64-pc-windows-gnu` builds to fail at link-time.