### PR TITLE
Build Rustix Only for Unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal_size"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Andrew Chin <achin@eminence32.net>"]
 description = "Gets the size of your Linux or Windows terminal"
 documentation = "https://docs.rs/terminal_size"
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.63"
 
 
-[target.'cfg(not(windows))'.dependencies]
+[target.'cfg(unix)'.dependencies]
 rustix = { version = "0.38.0", features = ["termios"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]


### PR DESCRIPTION
This little change allows building this library on `wasm32-unknown-unknown`. Not necessarily wowing for this library but it makes my life easier and we already have a fallback implementation:

```rs
#[cfg(not(any(unix, windows)))]
pub fn terminal_size() -> Option<(Width, Height)> {
    None
}
```