### PR TITLE
Update rustix to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.63"
 
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.38.0", features = ["termios"] }
+rustix = { version = "1.0.1", features = ["termios"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.59.0"


### PR DESCRIPTION
Rustix 1.0 recently got released: https://github.com/bytecodealliance/rustix/issues/753#issuecomment-2704635668

I was going through my dependencies and this seemed the only one left in need of an update. There are no code changes since rustix was already pretty stable for a while.