### PR TITLE
Update windows-sys to 0.60

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.63"
 rustix = { version = "1.0.1", features = ["termios"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.59.0"
+version = "0.60.0"
 features = [
     "Win32_Foundation",
     "Win32_System_Console",


### PR DESCRIPTION
Updated Cargo.toml and ran `cargo test` successfully. I wasn't sure how to further test for compatibility after the major version change.

Source repo notes that: "This is a major update since [metadata changes](https://github.com/microsoft/windows-rs/tree/master/crates/libs/bindgen/default) have caused breaking changes in the generated code." https://github.com/microsoft/windows-rs/releases/tag/66