### PR TITLE
Update MSRV to 1.71 and windows-sys to ">=0.60.59, <=0.61"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [1.63.0, stable, beta, nightly]
+        toolchain: [1.71.0, stable, beta, nightly]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [1.63.0, stable, beta, nightly]
+        toolchain: [1.71.0, stable, beta, nightly]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.63"
 rustix = { version = "1.0.1", features = ["termios"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.60.0"
+version = ">=0.59, <=0.61"
 features = [
     "Win32_Foundation",
     "Win32_System_Console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/eminence/terminal-size"
 keywords = ["terminal", "console", "term", "size", "dimensions"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.71"
 
 
 [target.'cfg(unix)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ if let Some((Width(w), Height(h))) = size {
 
 ## Minimum Rust Version
 
-This crate requires a minimum Rust version of 1.63.0 (2022-08-11).
+This crate requires a minimum Rust version of 1.71.0 (2023-07-13).
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Works on Linux, macOS, Windows, and illumos.
 //!
-//! This crate requires a minimum Rust version of 1.63.0 (2022-08-11).
+//! This crate requires a minimum Rust version of 1.71.0 (2023-07-13).
 //!
 //! # Example
 //!


### PR DESCRIPTION
(similar to #71)

Updated Cargo.toml and ran cargo test successfully. I wasn't sure how to further test for compatibility with the version change.

[Source repo notes that](https://github.com/microsoft/windows-rs/releases/tag/69):  
> This release is focused on upgrading the ecosystem to standardize on the [windows-link](https://crates.io/crates/windows-link) crate for universal raw-dylib support on Windows. This avoids all kinds of build complexity and undesirable complexity in dealing with the linker directly via import libs.
> 
> To date, the only major Windows crate that still uses the older [windows-targets](https://crates.io/crates/windows-targets) crate for linking is the [windows-sys](https://crates.io/crates/windows-sys) crate. This release updates windows-sys to depend on windows-link and thus raw-dylib unconditionally. This is required for some internal OS and Azure scenarios. It should also meaningfully reduce build time in general since the large windows-targets import lib crates no longer need to be downloaded at all.

Also, this time, I used range syntax since [windows-sys recommends](https://github.com/microsoft/windows-rs/tree/master/crates/libs/sys):  
> Using a range instead of the [default Caret requirements](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements) helps avoid duplicate versions in downstream graphs and improves resolver flexibility.